### PR TITLE
Raise error when API call fails

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Changelog
 =========
++ `1.2.3 (2018-01-23)`
+    Raise error when API call fails.
+
 + `1.2.2 (2017-12-14)`
     Possible to keep DB locks in order to see user activity (time, username, ...).
 

--- a/admin_page_lock/__init__.py
+++ b/admin_page_lock/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'admin_page_lock.apps.AdminPageLockConfig'
 NAME = 'django-admin-page-lock'
-VERSION = '1.2.2'
+VERSION = '1.2.3'

--- a/admin_page_lock/models/database_model.py
+++ b/admin_page_lock/models/database_model.py
@@ -63,12 +63,12 @@ class DatabasePageLockModel(BasePageLockModel, models.Model):
         page_locks = page_locks.filter(locked_out__gt=timezone.now())
 
         # Filter out data with `locked_out` older then now
-        # minus API_INTERVAL_DEFAULT.
+        # minus 2 * API_INTERVAL_DEFAULT.
         t = timezone.now() - datetime.timedelta(
-            milliseconds=API_INTERVAL_DEFAULT)
+            milliseconds=2 * API_INTERVAL_DEFAULT)
         page_locks = page_locks.filter(locked_out__gt=t)
 
-        # Get the lates instance of `DatabasePageLockModel` and check
+        # Get the latest instance of `DatabasePageLockModel` and check
         # its existence.
         page_lock = page_locks.first()
         if (

--- a/admin_page_lock/views.py
+++ b/admin_page_lock/views.py
@@ -1,14 +1,10 @@
 from __future__ import unicode_literals
 
 import json
-import logging
-import traceback
 
 from django.http import (
     HttpResponse,
-    HttpResponseServerError,
 )
-from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import View
 from admin_page_lock.settings import (
     HANDLER_FUNCTION_CLOSE_PAGE_CONNECTION,
@@ -32,9 +28,9 @@ class BasePageView(View):
             # Get and run handler function to get response data.
             handler_function = getattr(handler, self.HANDLER_FUNCTION)
             response_data = handler_function(req, *args, **kwargs)
-        except Exception:
-            logging.error(traceback.format_exc())
-            return HttpResponseServerError(_('Some error occured.'))
+        except Exception as e:
+            # Propagate error to django in order to be able to log it.
+            raise e
 
         response = HttpResponse(
             json.dumps(response_data),


### PR DESCRIPTION
There are three changes:
* make sure that when API fails the error is propagated to be able to log it;
* much more robust check of existence of  `DatabasePageLockModel` instance;
* update filtering `DatabasePageLockModel` instance .