### PR TITLE
Fix RawPostDataException("You cannot access body after reading from r…

### DIFF
--- a/admin_page_lock/__init__.py
+++ b/admin_page_lock/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'admin_page_lock.apps.AdminPageLockConfig'
 NAME = 'django-admin-page-lock'
-VERSION = '2.0.2'
+VERSION = '2.0.3'


### PR DESCRIPTION
The original hasattr(req, 'body') would call getattr(req, 'body') which would in turn call django/http/request.pydjango.http.request.HttpRequest#body:

```python
@property
def body(self):
    if not hasattr(self, '_body'):
        if self._read_started:
            raise RawPostDataException("You cannot access body after reading from request's data stream")
```