### PR TITLE
Encode url posted by ajax calls

### DIFF
--- a/admin_page_lock/static/js/page_lock.js
+++ b/admin_page_lock/static/js/page_lock.js
@@ -76,7 +76,7 @@ $(document).ready(function() {
 
     var call_api = function(url) {
         var data = {
-            'url': get_full_url(),
+            'url': encodeURIComponent(get_full_url()),
             'user_reference': user_reference,
         };
 


### PR DESCRIPTION
Pagelock currently does not work for URLs with any url params. These URLs are not correctly encoded and therefore not parsed in the backend. Please see my fix.