### PR TITLE
Add support for optional obj argument provided for inlines by django itself.

### DIFF
--- a/admin_page_lock/mixins/admin_mixin.py
+++ b/admin_page_lock/mixins/admin_mixin.py
@@ -84,8 +84,8 @@ class PageLockAdminMixin(BaseLockingMixin):
 
         return tuple(readonly_fields)
 
-    def has_add_permission(self, req):
-        can_add = super(PageLockAdminMixin, self).has_add_permission(req)
+    def has_add_permission(self, req, *args):
+        can_add = super(PageLockAdminMixin, self).has_add_permission(req, *args)
 
         if can_add and not self._is_locked(req):
             return True


### PR DESCRIPTION
In the case with inlines [Django (3.2) calls](https://github.com/django/django/blob/stable/3.2.x/django/contrib/admin/options.py#L601-L605) `has_add_permissions` with `obj` argument.