### PR TITLE
Update base_mixin.py

### DIFF
--- a/admin_page_lock/mixins/base_mixin.py
+++ b/admin_page_lock/mixins/base_mixin.py
@@ -16,7 +16,7 @@ from admin_page_lock.utils import get_page_lock_classes
 
 
 class BaseLockingMixin(object):
-    lock_change_view = False
+    lock_change_view = True
     lock_changelist_view = False
 
     def _add_extra_content(self, req, data):


### PR DESCRIPTION
Setting `lock_change_view` to `True` by default. Believing that someone using one of the locking mixins is probably willing to use the page-lock feature.